### PR TITLE
Use underscores instead of hyphens for setuptools 78

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kensho_kenverters"
-version = "1.2.1"
+version = "1.2.2"
 description = "Extract Output Translator Tools"
 readme = "README.md"
 authors = ["Valerie Faucon-Morin <valerie.fauconmorin@kensho.com>"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 
 [isort]
 profile = black
@@ -9,11 +9,11 @@ lines_after_imports = 2
 force_sort_within_sections = 1
 
 [flake8]
-max-line-length = 100
-show-source = True
-inline-quotes = single
-multiline-quotes = '''
-docstring-quotes = """
+max_line_length = 100
+show_source = True
+inline_quotes = single
+multiline_quotes = '''
+docstring_quotes = """
 select =
     E,
     F,


### PR DESCRIPTION
Hi @valerie-fauconmorin-kensho ! I ran into an issue with installing 1.2.1 since `setuptools` released [version 78](https://github.com/pypa/setuptools/blob/main/NEWS.rst#v7800) and deprecated hyphens and capital characters in `setup.cfg` options; this should fix it!