### PR TITLE
Remove validations for rows/cols for tables

### DIFF
--- a/kensho_kenverters/CHANGELOG.md
+++ b/kensho_kenverters/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.2.3
+
+Remove table validation for rows and columns to not fail downstream of Extract model failures
+
 ## v1.2.2
 
 Use underscores instead of hyphens for setuptools 78

--- a/kensho_kenverters/tables_utils.py
+++ b/kensho_kenverters/tables_utils.py
@@ -25,7 +25,11 @@ def _create_empty_annotation(row: int, col: int) -> AnnotationModel:
 def _validate_annotations(
     duplicated_annotations: list[AnnotationModel], max_row: int, max_col: int
 ) -> list[AnnotationModel]:
-    """Validate duplicated annotations."""
+    """Validate duplicated annotations.
+
+    Fill with empty annotations if rows or columns are missing.
+    """
+
     # Check all spans are 1 (annotations are duplicated)
     all_spans = [annotation.data.span for annotation in duplicated_annotations]
     if any(span != (1, 1) for span in all_spans):
@@ -36,6 +40,7 @@ def _validate_annotations(
     if len(set(all_indices)) != len(all_indices):
         raise ValueError("Overlapping indices in table.")
 
+    # Add any missing cells
     for row in range(max_row + 1):
         for col in range(max_col + 1):
             if (row, col) not in all_indices:

--- a/kensho_kenverters/tests/test_tables_utils.py
+++ b/kensho_kenverters/tests/test_tables_utils.py
@@ -57,7 +57,7 @@ class TestTablesUtils(TestCase):
         )
         self.assertEqual(expected_df.to_csv(), converted_df.to_csv())
 
-    def test_duplicate_spanning_annotations(self) -> None:
+    def test_duplicate_spanning_annotations_1_spans(self) -> None:
         # Test no duplication when all spans are 1
         duplicated = duplicate_spanning_annotations(
             self.parsed_serialized_document.annotations
@@ -417,6 +417,7 @@ class TestTablesUtils(TestCase):
 
         self.assertEqual(duplicated, expected_duplicated)
 
+    def test_duplicate_spanning_annotations_greater_1_spans(self) -> None:
         # Test properly duplicated when cells have a span > 1
         annotations = self.parsed_serialized_document.annotations
         annotations.pop(-1)
@@ -775,3 +776,53 @@ class TestTablesUtils(TestCase):
         ]
         duplicated = duplicate_spanning_annotations(annotations)
         self.assertEqual(expected_duplicated, duplicated)
+
+    def test_duplicate_spanning_annotations_missing_cells(self) -> None:
+        # Test missing cells
+        annotations = [
+            AnnotationModel(
+                content_uids=["7"],
+                data=AnnotationDataModel(index=(0, 0), span=(1, 1)),
+                type="table_structure",
+                locations=[
+                    LocationModel(
+                        height=0.01188,
+                        width=0.22128,
+                        x=0.16008,
+                        y=0.40464,
+                        page_number=0,
+                    )
+                ],
+            ),
+            AnnotationModel(
+                content_uids=["8"],
+                data=AnnotationDataModel(index=(0, 1), span=(1, 1)),
+                type="table_structure",
+                locations=[
+                    LocationModel(
+                        height=0.01188,
+                        width=0.22128,
+                        x=0.16008,
+                        y=0.80464,
+                        page_number=0,
+                    )
+                ],
+            ),
+            AnnotationModel(
+                content_uids=["9"],
+                data=AnnotationDataModel(index=(3, 0), span=(1, 1)),
+                type="table_structure",
+                locations=[
+                    LocationModel(
+                        height=0.01188,
+                        width=0.22128,
+                        x=0.7008,
+                        y=0.40464,
+                        page_number=0,
+                    )
+                ],
+            ),
+        ]
+
+        duplicated = duplicate_spanning_annotations(annotations)
+        self.assertEqual(len(duplicated), 8)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kensho_kenverters"
-version = "1.2.2"
+version = "1.2.3"
 description = "Extract Output Translator Tools"
 readme = "README.md"
 authors = ["Valerie Faucon-Morin <valerie.fauconmorin@kensho.com>"]


### PR DESCRIPTION
Remove validations that there are no missing rows or columns in tables. In theory there should not be any missing rows or columns. However, this is a model failure, so it should not fail at the kenverters stage since it's not kenverters's fault. This was requested by users.

kenverters will create empty table cells when there are missing columns or rows when converting from output to dataframes.

In addition to the test added here, I tested on a full structured output locally that had this issue, and it now parses fine.