### PR TITLE
Fix PyPI Release Issue

### DIFF
--- a/kensho_kenverters/CHANGELOG.md
+++ b/kensho_kenverters/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.2.7
+
+Fixing PyPI version mismatch - no code changes
+
+## v1.2.6
+* Another addition to enable FIGURE types
+
+
 ## v1.2.5
 * Add handling for FIGURE types in Extract output
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kensho_kenverters"
-version = "1.2.5"
+version = "1.2.7"
 description = "Extract Output Translator Tools"
 readme = "README.md"
 authors = ["Valerie Faucon-Morin <valerie.fauconmorin@kensho.com>"]


### PR DESCRIPTION
PyPI versioning doesn't match repo. Fixing with a new version number