### PR TITLE
[kensho_kenverters] Add table row header hierarchy models.

### DIFF
--- a/kensho_kenverters/CHANGELOG.md
+++ b/kensho_kenverters/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v3.1.1
+
+### Added
+
+* Add table row header hierarchy models. 
+
 ## v3.1.0
 
 ### Added

--- a/kensho_kenverters/extract_output_models.py
+++ b/kensho_kenverters/extract_output_models.py
@@ -36,6 +36,7 @@ class Table(NamedTuple):
     table_type: TableCategoryType
     locations: list[LocationType] | None = None
     cells: list[Cell] | None = None
+    hierarchy_tree: "TableDataFrameHierarchyModel | None" = None
 
 
 class LocationModel(BaseModel):
@@ -137,6 +138,56 @@ class TableGridAndStructure(NamedTuple):
     table_category_type: TableCategoryType
     table_string_grid: list[list[str]]
     table_structure_annotations: list[TableStructureAnnotationModel]
+
+
+class BaseTableHierarchyNodeModel(BaseModel):
+    """Abstract base for table hierarchy tree nodes.
+
+    All hierarchy tree representations share a node identifier (uid and text)
+    and a node type. Subclasses define their own children and contents types.
+    """
+
+    node_uid: str
+    node_text: str | None = None
+    node_type: str
+
+
+class TableCellHierarchyTreeModel(BaseTableHierarchyNodeModel):
+    """A node in the table cell hierarchy tree representing the row header structure.
+
+    The tree shows the hierarchical structure of a table's projected row headers.
+    Children are other projected row header cells (sub-categories), and contents are
+    the table_structure annotations for the corresponding leftmost cells (data rows)
+    that belong to this projected row header.
+    """
+
+    children: list["TableCellHierarchyTreeModel"]
+    contents: list[TableStructureAnnotationModel]
+
+
+class TableGridHierarchyModel(BaseTableHierarchyNodeModel):
+    """A node in the table grid hierarchy tree with human-readable text content.
+
+    Similar to TableCellHierarchyTreeModel, but instead of annotation objects,
+    the node has text recovered from the content tree, and the contents are a
+    2D string grid recovered from the annotations.
+    """
+
+    children: list["TableGridHierarchyModel"]
+    contents: list[list[str]]
+
+
+class TableDataFrameHierarchyModel(BaseTableHierarchyNodeModel):
+    """A node in the table DataFrame hierarchy tree.
+
+    Similar to TableGridHierarchyModel, but the contents are a pandas DataFrame
+    converted from the string grid.
+    """
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    children: list["TableDataFrameHierarchyModel"]
+    contents: pd.DataFrame
 
 
 class ContentSegmentModel(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kensho_kenverters"
-version = "3.1.0"
+version = "3.1.1"
 description = "Extract Output Translator Tools"
 readme = "README.md"
 authors = ["Valerie Faucon-Morin <valerie.fauconmorin@kensho.com>"]


### PR DESCRIPTION
Added

- Add table row header hierarchy models to support surfacing the table row header hierarchy tree based on the predicted row header hierarchy.